### PR TITLE
Change jwt.decode to jwt.verify

### DIFF
--- a/server/src/api/resources/email/email.controller.js
+++ b/server/src/api/resources/email/email.controller.js
@@ -71,7 +71,7 @@ export const receiveNewPassword = (req, res) => {
 
     .then(user => {
       const secret = user.password + "-" + user.createdAt
-      const payload = jwt.decode(token, secret)
+      const payload = jwt.verify(token, secret)
       if (payload.userId === user.id) {
         bcrypt.genSalt(10, function(err, salt) {
           if (err) return


### PR DESCRIPTION
# Description

In the documentation for the "jsonwebtoken" library, it gives the following warning for the function jwt.decode:

******
https://www.npmjs.com/package/jsonwebtoken

Warning: This will not verify whether the signature is valid. You should not use this for untrusted messages. You most likely want to use jwt.verify instead.
******

Therefore, to ensure that the signature is valid, the jwt.verify should be called, not jwt.decode.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has not been tested.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
